### PR TITLE
updated to latest torii

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/simplabs/ember-cli-simple-auth-torii",
   "dependencies": {
-    "torii": "0.3.3",
+    "torii": "0.3.5",
     "ember-cli-simple-auth": "0.8.0-beta.2"
   }
 }


### PR DESCRIPTION
Any chance we can update to the latest torii?

For me, at least, this has an important fix solving a race condition related to `postMessage()` and closing the popup window for many oauth workflows. 
